### PR TITLE
Implement dynamic station pipelining system

### DIFF
--- a/include/station_config.h
+++ b/include/station_config.h
@@ -20,8 +20,8 @@
 
 // ===== TEST CONFIGURATIONS =====
 // #define CONFIG_FOUR_CW          // Four CW/Morse stations for CW testing
-// #define CONFIG_FIVE_CW          // Four CW/Morse stations for simulating Field Day traffic
-#define CONFIG_FILE_PILE_UP     // Five CW/Morse stations simulating Scarborough Reef pile-up (BS77H variations)
+#define CONFIG_FIVE_CW          // Four CW/Morse stations for simulating Field Day traffic
+// #define CONFIG_FILE_PILE_UP     // Five CW/Morse stations simulating Scarborough Reef pile-up (BS77H variations)
 // #define CONFIG_FOUR_NUMBERS     // Four Numbers stations for spooky testing
 // #define CONFIG_FOUR_PAGER       // Four Pager stations for digital testing
 // #define CONFIG_FOUR_RTTY        // Four RTTY stations for RTTY testing

--- a/include/station_manager.h
+++ b/include/station_manager.h
@@ -15,6 +15,7 @@
 #define PIPELINE_STATION_SPACING 5000    // Minimum 5 kHz between stations
 #define PIPELINE_AUDIBLE_RANGE 5000      // Range where stations become audible
 #define PIPELINE_REALLOC_THRESHOLD 3000  // Reallocate when VFO moves 3 kHz
+#define PIPELINE_TUNE_DETECT_THRESHOLD 100  // Minimum Hz change to detect tuning activity
 
 class StationManager {
 public:
@@ -45,7 +46,6 @@ private:
     uint32_t last_vfo_freq;
     uint32_t pipeline_center_freq;
     int tuning_direction; // -1 = down, 0 = stopped, 1 = up
-    unsigned long last_update_time;
     unsigned long last_tuning_time; // Last time VFO frequency changed significantly
     
     // Private methods
@@ -53,7 +53,6 @@ private:
     void deactivateStation(int idx);
     int findDormantStation();
     void reallocateStations(uint32_t vfo_freq);
-    uint32_t generateStationFrequency(uint32_t center_freq, int offset_index);
     void updateStationStates(uint32_t vfo_freq);
     int calculateTuningDirection(uint32_t current_freq, uint32_t last_freq);
     bool canInterruptStation(int station_idx, uint32_t vfo_freq) const;

--- a/include/station_manager.h
+++ b/include/station_manager.h
@@ -4,8 +4,17 @@
 #include "sim_transmitter.h"
 #include <stdint.h>
 
-#define MAX_STATIONS 6
+#define MAX_STATIONS 3
 #define MAX_AD9833 4
+
+// Debug control - disabled for production
+// #define DEBUG_PIPELINING  // Enable for troubleshooting pipelining issues
+
+// Dynamic pipelining configuration
+#define PIPELINE_LOOKAHEAD_RANGE 5000    // 5 kHz ahead/behind VFO - very aggressive for testing
+#define PIPELINE_STATION_SPACING 5000    // Minimum 5 kHz between stations
+#define PIPELINE_AUDIBLE_RANGE 5000      // Range where stations become audible
+#define PIPELINE_REALLOC_THRESHOLD 3000  // Reallocate when VFO moves 3 kHz
 
 class StationManager {
 public:
@@ -15,13 +24,39 @@ public:
     void recycleDormantStations(uint32_t vfo_freq);
     SimTransmitter* getStation(int idx);
     int getActiveStationCount() const;
-
+    
+    // Dynamic pipelining methods
+    void enableDynamicPipelining(bool enable = true);
+    void setupPipeline(uint32_t vfo_freq);
+    void updatePipeline(uint32_t vfo_freq);
+    
+    // Runtime configuration methods
+    bool isDynamicPipeliningEnabled() const { return pipeline_enabled; }
+    bool isPipelinePaused() const { return pipeline_enabled && tuning_direction == 0; }
+    int getTuningDirection() const { return tuning_direction; }
+    uint32_t getPipelineCenterFreq() const { return pipeline_center_freq; }
+    
 private:
     SimTransmitter* stations[MAX_STATIONS];
     int ad9833_assignment[MAX_AD9833]; // Maps AD9833 channels to station indices
+    
+    // Dynamic pipelining state
+    bool pipeline_enabled;
+    uint32_t last_vfo_freq;
+    uint32_t pipeline_center_freq;
+    int tuning_direction; // -1 = down, 0 = stopped, 1 = up
+    unsigned long last_update_time;
+    unsigned long last_tuning_time; // Last time VFO frequency changed significantly
+    
+    // Private methods
     void activateStation(int idx, uint32_t freq);
     void deactivateStation(int idx);
     int findDormantStation();
+    void reallocateStations(uint32_t vfo_freq);
+    uint32_t generateStationFrequency(uint32_t center_freq, int offset_index);
+    void updateStationStates(uint32_t vfo_freq);
+    int calculateTuningDirection(uint32_t current_freq, uint32_t last_freq);
+    bool canInterruptStation(int station_idx, uint32_t vfo_freq) const;
 };
 
 #endif // STATION_MANAGER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -789,11 +789,11 @@ void loop()
 	cw_station3.begin(time + random(3000));
 	cw_station3.set_station_state(AUDIBLE);
 	
-	// cw_station4.begin(time + random(4000));
-	// cw_station4.set_station_state(AUDIBLE);
+	cw_station4.begin(time + random(4000));
+	cw_station4.set_station_state(AUDIBLE);
 
-	// cw_station5.begin(time + random(5000));
-	// cw_station5.set_station_state(AUDIBLE);
+	cw_station5.begin(time + random(5000));
+	cw_station5.set_station_state(AUDIBLE);
 #endif
 
 #ifdef CONFIG_FILE_PILE_UP

--- a/src/sim_transmitter.cpp
+++ b/src/sim_transmitter.cpp
@@ -94,10 +94,13 @@ bool SimTransmitter::reinitialize(unsigned long time, float fixed_freq)
     _active = false;
     _station_state = ACTIVE;  // Station is now active at new frequency
     
+    // Start the station with the new frequency
+    bool success = begin(time);
+    
     // Subclasses should override this method to reinitialize their specific content
     // (e.g., new morse messages, different WPM, new pager content, etc.)
     
-    return true;
+    return success;
 }
 
 void SimTransmitter::set_station_state(StationState new_state)


### PR DESCRIPTION
- Add StationManager class with dynamic pipelining functionality
- Recycle fixed pool of 3 stations as user tunes VFO
- Only reallocate stations when user is actively tuning (5s settle time)
- Allow interrupting AUDIBLE stations when outside audible range (5 kHz)
- Prioritize recycling furthest stations from VFO
- Maintain station natural behavior and drift
- Reduce audible range from 10 kHz to 5 kHz for responsive pipelining
- Add efficient candidate selection and reallocation logic
- Preserve original station pool size reduction to 3 stations
- Clean up debug output for production use

Key features:
- Responsive 'infinite band' experience
- No dynamic memory allocation
- Non-intrusive to audible stations within range
- Efficient resource management with only 3 stations