### PR TITLE
Feature/pipelining realism improvements

### DIFF
--- a/include/sim_station.h
+++ b/include/sim_station.h
@@ -25,6 +25,7 @@ public:
 
     void realize();
     void apply_wpm_drift();         // Add slight WPM drift for realism
+    virtual void randomize() override;  // Re-randomize callsign, WPM, and fist quality
     
     // Set station into retry state (used when initialization fails)
     void set_retry_state(unsigned long next_try_time);

--- a/include/sim_test.h
+++ b/include/sim_test.h
@@ -1,0 +1,38 @@
+#ifndef __SIM_TEST_H__
+#define __SIM_TEST_H__
+
+#include "async_pager.h"
+#include "sim_transmitter.h"
+
+class SignalMeter; // Forward declaration
+
+// Test tone frequency range (Hz offset from VFO) - DTMF-like range for pleasant listening
+#define TEST_TONE_MIN_OFFSET 650.0    // Minimum tone frequency offset (DTMF-like range)
+#define TEST_TONE_MAX_OFFSET 1650.0   // Maximum tone frequency offset (DTMF-like range)
+#define TEST_TONE_MIN_SEPARATION 100.0 // Minimum separation between tones (suitable for DTMF-like range)
+
+class SimTest : public SimTransmitter
+{
+public:
+    SimTest(WaveGenPool *wave_gen_pool, SignalMeter *signal_meter, float fixed_freq, 
+            float toggle_rate_hz = 5.0, float tone_a_offset = 1000.0, float tone_b_offset = 2000.0);
+    virtual bool begin(unsigned long time) override;
+    virtual bool update(Mode *mode) override;
+    virtual bool step(unsigned long time) override;
+    void realize();
+    // Debug method to display current tone pair
+    void debug_print_tone_pair() const;
+    
+    // Method to generate new tone pairs for testing
+    void generate_new_tone_pair();
+
+private:
+    AsyncPager _pager;
+    float _current_tone_a_offset;
+    float _current_tone_b_offset;
+    float _toggle_rate_hz;          // Toggle rate in Hz
+    unsigned long _toggle_interval; // Toggle interval in milliseconds (calculated from rate)
+    SignalMeter *_signal_meter;     // Pointer to signal meter for charge pulses
+};
+
+#endif

--- a/include/sim_transmitter.h
+++ b/include/sim_transmitter.h
@@ -44,6 +44,7 @@ public:
 
     // Dynamic station management methods
     virtual bool reinitialize(unsigned long time, float fixed_freq);  // Reinitialize with new frequency
+    virtual void randomize();  // Re-randomize station properties (callsign, WPM, etc.) - default implementation does nothing
     void set_station_state(StationState new_state);  // Change station state
     StationState get_station_state() const;  // Get current station state
     bool is_audible() const;  // True if station has AD9833 generator assigned

--- a/include/station_config.h
+++ b/include/station_config.h
@@ -11,7 +11,7 @@
 // #define CONFIG_MIXED_STATIONS    // Default: All different station types
 
 // ===== DEVELOPMENT CONFIGURATION =====  
-// #define CONFIG_DEV_LOW_RAM       // Development: Minimal RAM usage for development work
+#define CONFIG_DEV_LOW_RAM       // Development: Minimal RAM usage for development work
                                  // SAVES ~191 BYTES RAM: Disables RTTY and Pager stations
                                  // Use this for dynamic station pipelining development
 
@@ -20,7 +20,8 @@
 
 // ===== TEST CONFIGURATIONS =====
 // #define CONFIG_FOUR_CW          // Four CW/Morse stations for CW testing
-#define CONFIG_FIVE_CW          // Four CW/Morse stations for simulating Field Day traffic
+// #define CONFIG_FIVE_CW          // Four CW/Morse stations for simulating Field Day traffic
+// #define CONFIG_TEST_PERFORMANCE  // Single test station for measuring main loop performance
 // #define CONFIG_FILE_PILE_UP     // Five CW/Morse stations simulating Scarborough Reef pile-up (BS77H variations)
 // #define CONFIG_FOUR_NUMBERS     // Four Numbers stations for spooky testing
 // #define CONFIG_FOUR_PAGER       // Four Pager stations for digital testing
@@ -68,6 +69,7 @@
     // Development: Optimized for low RAM usage during development
     #define ENABLE_MORSE_STATION    // Basic CW/Morse station (SimStation) - essential for testing
     #define ENABLE_NUMBERS_STATION  // Numbers Station (SimNumbers) - moderate RAM usage
+    #define ENABLE_TEST_STATION     // Test Station (SimTest) - for loop performance testing
     // #define ENABLE_PAGER_STATION    // Pager Station (SimPager) - disabled to save RAM
     // #define ENABLE_RTTY_STATION     // RTTY Station (SimRTTY) - disabled to save RAM 
     // #define ENABLE_JAMMER_STATION   // Jammer Station (SimJammer) - disabled to save RAM
@@ -133,6 +135,12 @@
     #define ENABLE_CW_CLUSTER_STATIONS
     #define ENABLE_MORSE_STATION
     // Other stations disabled for focused CW listening
+#endif
+
+#ifdef CONFIG_TEST_PERFORMANCE
+    // Performance testing: Single test station for measuring main loop speed
+    #define ENABLE_TEST_STATION
+    // All other stations disabled for clean performance measurement
 #endif
 
 #endif // STATION_CONFIG_H

--- a/include/station_config.h
+++ b/include/station_config.h
@@ -8,7 +8,7 @@
 // Choose ONE configuration mode by uncommenting it
 
 // ===== PRODUCTION CONFIGURATION =====
-#define CONFIG_MIXED_STATIONS    // Default: All different station types
+// #define CONFIG_MIXED_STATIONS    // Default: All different station types
 
 // ===== DEVELOPMENT CONFIGURATION =====  
 // #define CONFIG_DEV_LOW_RAM       // Development: Minimal RAM usage for development work
@@ -20,7 +20,7 @@
 
 // ===== TEST CONFIGURATIONS =====
 // #define CONFIG_FOUR_CW          // Four CW/Morse stations for CW testing
-// #define CONFIG_FIVE_CW          // Four CW/Morse stations for simulating Field Day traffic
+#define CONFIG_FIVE_CW          // Four CW/Morse stations for simulating Field Day traffic
 // #define CONFIG_FILE_PILE_UP     // Five CW/Morse stations simulating Scarborough Reef pile-up (BS77H variations)
 // #define CONFIG_FOUR_NUMBERS     // Four Numbers stations for spooky testing
 // #define CONFIG_FOUR_PAGER       // Four Pager stations for digital testing

--- a/include/station_config.h
+++ b/include/station_config.h
@@ -11,7 +11,7 @@
 // #define CONFIG_MIXED_STATIONS    // Default: All different station types
 
 // ===== DEVELOPMENT CONFIGURATION =====  
-#define CONFIG_DEV_LOW_RAM       // Development: Minimal RAM usage for development work
+// #define CONFIG_DEV_LOW_RAM       // Development: Minimal RAM usage for development work
                                  // SAVES ~191 BYTES RAM: Disables RTTY and Pager stations
                                  // Use this for dynamic station pipelining development
 
@@ -20,7 +20,7 @@
 
 // ===== TEST CONFIGURATIONS =====
 // #define CONFIG_FOUR_CW          // Four CW/Morse stations for CW testing
-// #define CONFIG_FIVE_CW          // Four CW/Morse stations for simulating Field Day traffic
+#define CONFIG_FIVE_CW          // Four CW/Morse stations for simulating Field Day traffic
 // #define CONFIG_TEST_PERFORMANCE  // Single test station for measuring main loop performance
 // #define CONFIG_FILE_PILE_UP     // Five CW/Morse stations simulating Scarborough Reef pile-up (BS77H variations)
 // #define CONFIG_FOUR_NUMBERS     // Four Numbers stations for spooky testing

--- a/include/station_manager.h
+++ b/include/station_manager.h
@@ -11,7 +11,7 @@
 // #define DEBUG_PIPELINING  // Enable for troubleshooting pipelining issues
 
 // Dynamic pipelining configuration
-#define PIPELINE_LOOKAHEAD_RANGE 5000    // 5 kHz ahead/behind VFO - very aggressive for testing
+#define PIPELINE_LOOKAHEAD_RANGE 8000    // 8 kHz ahead/behind VFO - accommodate 7.2 kHz station placement
 #define PIPELINE_STATION_SPACING 5000    // Minimum 5 kHz between stations
 #define PIPELINE_AUDIBLE_RANGE 5000      // Range where stations become audible
 #define PIPELINE_REALLOC_THRESHOLD 3000  // Reallocate when VFO moves 3 kHz

--- a/pipeline-testing-notes-1.md
+++ b/pipeline-testing-notes-1.md
@@ -1,0 +1,20 @@
+
+## must haves
+- newly relocated stations need to be placed within the radio spectrum _asymmetrically_ when tuning up versus when tuning down to add import realism
+    - (Good) the tuning up direction currently works well:
+        - while tuning up, the new stations appear, and because of the BFO offset, they are not heard immediately, but are naturally _dialed in_ as continue turning the tuning knob
+    - (Not Good) the tuning down direction sounds unnatural
+        - while tuning down, the new stations **pop** into place, because they are placed so that their audible frequency is near the top of the max audible frequency 5000, which can still be easily heard
+        - It would be better if they are placed a bit further down the dial allowing them to be more naturally dialed into. The BFO Offset might be the right amount. 
+- newly relocated stations should be newly-randomimzed so they appear to be a whole brand new station
+    - new callsign
+    - WPM drift
+
+## look into
+- while tuning down quickly a long way, so it pulled all the stations down, they all popped into place at once, sounding unnatural
+
+## nice to haves
+- have a flag that indicates whether or not a station is _allowed_ to be automatically moved (though currently it's handled well by type of station)
+- when randomizing a station's properties like WPM also random Fist Quality
+- when stations drift, if they started within the limmits of a ham band, they are restricted from moving outside of the legal band limits
+- assign a probability to by _station kind_ for it to be chosen for relocation (for example, CW station high, numbers stations low, pager station zero)

--- a/src/sim_test.cpp
+++ b/src/sim_test.cpp
@@ -1,0 +1,160 @@
+#include "vfo.h"
+#include "wavegen.h"
+#include "wave_gen_pool.h"
+#include "sim_test.h"
+#include "signal_meter.h"
+
+SimTest::SimTest(WaveGenPool *wave_gen_pool, SignalMeter *signal_meter, float fixed_freq,
+                 float toggle_rate_hz, float tone_a_offset, float tone_b_offset) 
+    : SimTransmitter(wave_gen_pool, fixed_freq), _signal_meter(signal_meter),
+      _toggle_rate_hz(toggle_rate_hz), _current_tone_a_offset(tone_a_offset), 
+      _current_tone_b_offset(tone_b_offset)
+{
+    // Calculate toggle interval in milliseconds from Hz rate
+    _toggle_interval = (unsigned long)(1000.0 / _toggle_rate_hz);
+    
+    // Ensure minimum interval of 10ms to prevent system overload
+    if (_toggle_interval < 10) {
+        _toggle_interval = 10;
+        _toggle_rate_hz = 100.0; // Limit to 100 Hz maximum
+    }
+    
+    // Test transmission will be started in begin() method
+}
+
+bool SimTest::begin(unsigned long time)
+{
+    if(!common_begin(time, _fixed_freq))
+        return false;
+
+    // Start test transmission with repeat enabled
+    _pager.start_pager_transmission(true);
+
+    // Check if we have a valid realizer before accessing it
+    if(_realizer == -1) {
+        return false;  // No realizer available
+    }
+
+    WaveGen *wavegen = _wave_gen_pool->access_realizer(_realizer);
+
+    // Initialize both channels to silent
+    wavegen->set_frequency(SILENT_FREQ, false);
+    wavegen->set_frequency(SILENT_FREQ, true);
+
+    return true;
+}
+
+void SimTest::realize()
+{
+    if(!check_frequency_bounds()) {
+        return;  // Out of audible range
+    }
+    
+    // Don't try to access wave generator if we don't have one
+    if(_realizer == -1) {
+        return;
+    }
+    
+    WaveGen *wavegen = _wave_gen_pool->access_realizer(_realizer);
+    
+    if(_active) {
+        // Use configurable frequencies with configurable toggle rate
+        static bool toggle_state = false;
+        static unsigned long last_realize_toggle = 0;
+        unsigned long current_time = millis();
+        
+        if (current_time - last_realize_toggle > _toggle_interval) {
+            toggle_state = !toggle_state;
+            last_realize_toggle = current_time;
+        }
+        
+        float tone_offset;
+        if (toggle_state) {
+            tone_offset = _current_tone_a_offset;  // Use configured tone A
+        } else {
+            tone_offset = _current_tone_b_offset;  // Use configured tone B
+        }
+        
+        // Use the working SimPager method: _frequency + offset
+        wavegen->set_frequency(_frequency + tone_offset, true);
+        wavegen->set_frequency(_frequency + tone_offset, false);
+    } else {
+        // Explicitly set silent frequencies when inactive
+        wavegen->set_frequency(SILENT_FREQ, true);
+        wavegen->set_frequency(SILENT_FREQ, false);
+    }
+    
+    wavegen->set_active_frequency(_active);
+}
+
+bool SimTest::update(Mode *mode)
+{
+    common_frequency_update(mode);
+
+    if(_enabled) {
+        // Note: We don't set frequencies here like RTTY does
+        // Test frequencies are set in realize() based on current tone
+    }
+
+    realize();
+    return true;
+}
+
+bool SimTest::step(unsigned long time)
+{
+    // Use configurable toggle rate for performance testing
+    static unsigned long last_toggle = 0;
+    static bool toggle_state = false;
+    
+    if (!_active) {
+        // Turn on initially
+        _active = true;
+        realize();
+        send_carrier_charge_pulse(_signal_meter);
+    } else {
+        // Toggle frequency at configured rate
+        if (time - last_toggle > _toggle_interval) {
+            toggle_state = !toggle_state;
+            last_toggle = time;
+            realize(); // This will pick up the new toggle_state in realize()
+        }
+        // Send charge pulse to keep signal meter active
+        send_carrier_charge_pulse(_signal_meter);
+    }
+
+    return true;
+}
+
+void SimTest::generate_new_tone_pair()
+{
+    // Generate random tone pair similar to DTMF frequencies
+    // Range: 650-1650 Hz offset, minimum 200 Hz separation
+    
+    float frequency_range = TEST_TONE_MAX_OFFSET - TEST_TONE_MIN_OFFSET;
+    
+    // Arduino random() function
+    _current_tone_a_offset = TEST_TONE_MIN_OFFSET + 
+        random((long)(frequency_range - TEST_TONE_MIN_SEPARATION));
+    
+    // Generate second tone with minimum separation
+    float remaining_range = frequency_range - TEST_TONE_MIN_SEPARATION;
+    float tone_b_base = random((long)remaining_range);
+    
+    // Ensure minimum separation
+    if (tone_b_base < _current_tone_a_offset - TEST_TONE_MIN_OFFSET) {
+        _current_tone_b_offset = TEST_TONE_MIN_OFFSET + tone_b_base;
+    } else {
+        _current_tone_b_offset = _current_tone_a_offset + TEST_TONE_MIN_SEPARATION + 
+            (tone_b_base - (_current_tone_a_offset - TEST_TONE_MIN_OFFSET));
+    }
+
+    // Ensure tone B doesn't exceed maximum
+    if (_current_tone_b_offset > TEST_TONE_MAX_OFFSET) {
+        _current_tone_b_offset = TEST_TONE_MAX_OFFSET;
+    }
+}
+
+void SimTest::debug_print_tone_pair() const
+{
+    // Debug output not needed for Arduino build
+}

--- a/src/sim_transmitter.cpp
+++ b/src/sim_transmitter.cpp
@@ -103,6 +103,13 @@ bool SimTransmitter::reinitialize(unsigned long time, float fixed_freq)
     return success;
 }
 
+void SimTransmitter::randomize()
+{
+    // Default implementation: no randomization
+    // Subclasses should override this to randomize their specific properties
+    // (e.g., callsigns, WPM, fist quality, message content, etc.)
+}
+
 void SimTransmitter::set_station_state(StationState new_state)
 {
     StationState old_state = _station_state;

--- a/src/station_manager.cpp
+++ b/src/station_manager.cpp
@@ -300,11 +300,13 @@ void StationManager::reallocateStations(uint32_t vfo_freq) {
         uint32_t new_freq;
         
         if (tuning_direction > 0) {
-            // Tuning up - move stations just ahead of VFO (much closer)
-            new_freq = vfo_freq + 2000 + (stations_moved * 1000); // Only 2-6 kHz ahead
+            // Tuning up - move stations ahead of VFO (higher frequencies)
+            new_freq = vfo_freq + 2000 + (stations_moved * 1000); // 2-6 kHz ahead
         } else {
-            // Tuning down - move stations just behind VFO  
-            new_freq = vfo_freq - 2000 - (stations_moved * 1000); // Only 2-6 kHz behind
+            // Tuning down - place stations BELOW VFO so they can be dialed into
+            // As VFO frequency decreases (tuning down), user will eventually tune into these stations
+            // Place them 5.7-7.2 kHz below VFO so they start inaudible but become audible as user tunes down
+            new_freq = vfo_freq - 5700 - (stations_moved * 500); // 5.7-7.2 kHz behind (below VFO)
         }
         
         // Ensure we don't go below minimum frequency
@@ -329,26 +331,43 @@ void StationManager::updateStationStates(uint32_t vfo_freq) {
         if (!stations[i]->isActive()) continue; // Skip inactive stations
         
         uint32_t station_freq = (uint32_t)stations[i]->get_fixed_frequency();
-        int32_t freq_diff = abs((int32_t)(station_freq - vfo_freq));
+        int32_t signed_freq_diff = (int32_t)(station_freq - vfo_freq);
+        uint32_t abs_freq_diff = abs(signed_freq_diff);
         
         StationState current_state = stations[i]->get_station_state();
         
-        if (freq_diff <= PIPELINE_AUDIBLE_RANGE) {
+        if (abs_freq_diff <= PIPELINE_AUDIBLE_RANGE) {
             // Station is close enough to be potentially audible
             if (current_state == DORMANT) {
                 stations[i]->set_station_state(ACTIVE);
             }
             // Don't downgrade AUDIBLE or SILENT stations - let allocateAD9833() handle that
-        } else if (freq_diff > PIPELINE_LOOKAHEAD_RANGE) {
-            // Station is very far away - mark as dormant to save resources
-            if (current_state != DORMANT) {
-                stations[i]->set_station_state(DORMANT);
+        } else {
+            // Use asymmetric lookahead ranges based on current tuning direction
+            uint32_t effective_lookahead_range;
+            
+            if (tuning_direction > 0) {
+                // Tuning up - use standard range for stations above VFO, smaller for below
+                effective_lookahead_range = (signed_freq_diff > 0) ? PIPELINE_LOOKAHEAD_RANGE : PIPELINE_LOOKAHEAD_RANGE / 2;
+            } else if (tuning_direction < 0) {
+                // Tuning down - use larger range for stations below VFO, smaller for above
+                effective_lookahead_range = (signed_freq_diff < 0) ? 8000 : PIPELINE_LOOKAHEAD_RANGE / 2; // 8kHz for stations below when tuning down
+            } else {
+                // Not tuning - use symmetric range
+                effective_lookahead_range = PIPELINE_LOOKAHEAD_RANGE;
             }
-        }
-        // Stations between AUDIBLE_RANGE and LOOKAHEAD_RANGE stay in their current state
-        // unless they're DORMANT, in which case they become ACTIVE
-        else if (current_state == DORMANT) {
-            stations[i]->set_station_state(ACTIVE);
+            
+            if (abs_freq_diff > effective_lookahead_range) {
+                // Station is very far away - mark as dormant to save resources
+                if (current_state != DORMANT) {
+                    stations[i]->set_station_state(DORMANT);
+                }
+            }
+            // Stations between AUDIBLE_RANGE and effective_lookahead_range stay in their current state
+            // unless they're DORMANT, in which case they become ACTIVE
+            else if (current_state == DORMANT) {
+                stations[i]->set_station_state(ACTIVE);
+            }
         }
     }
 }

--- a/src/station_manager.cpp
+++ b/src/station_manager.cpp
@@ -314,6 +314,10 @@ void StationManager::reallocateStations(uint32_t vfo_freq) {
         
         // Recycle the station - it's safe to interrupt since we checked above
         stations[i]->reinitialize(millis(), new_freq);
+        
+        // Re-randomize station properties to make it feel like a completely new station
+        stations[i]->randomize();
+        
         stations_moved++;
         
         #ifdef DEBUG_PIPELINING

--- a/src/vfo.cpp
+++ b/src/vfo.cpp
@@ -17,7 +17,7 @@ VFO::VFO(const char *title, float frequency, unsigned long step, RealizationPool
 // step needs to be in 0.1Hz units
 // when step is 0.1Hz, use xxxxxxx.y format
 void VFO::update_display(HT16K33Disp *display){
-    if(_frequency >= 10000000L){
+    if(_frequency >= 100000000L){
         // Display as 2450.0000 in MHz
         int megpart = _frequency / 1000000L;
         long decpart = _frequency - (megpart * 1000000L);
@@ -33,7 +33,7 @@ void VFO::update_display(HT16K33Disp *display){
         remainder = remainder - (kilpart * 1000L);
         int unipart = remainder;
         
-        sprintf(display_text_buffer, " %1d.%03d.%03d", megpart, kilpart, unipart);
+        sprintf(display_text_buffer, "%2d.%03d.%03d", megpart, kilpart, unipart);
         
     } else {
         // Display in Hz


### PR DESCRIPTION
Make the look-ahead asymmetrical between tuning up vs. down to improve the realism of the station appearance (so it can be dialed-into, appearing at the upper audible frequency limit). 